### PR TITLE
Change variable names in Google Analytics script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -131,10 +131,10 @@ Using gulp-sourcemaps, we are able to maintain transformation history throughout
         <script src="js/highlight.js"></script>
         <script src="js/script.js"></script>
         <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+          !function(g,u,l,p,j,s){g.GoogleAnalyticsObject=l;g[l]||(g[l]=function(){
+          (g[l].q=g[l].q||[]).push(arguments)});g[l].l=+new Date;j=u.createElement(p);
+          s=u.getElementsByTagName(p)[0];j.src='//www.google-analytics.com/analytics.js';
+          s.parentNode.insertBefore(j,s)}(window,document,'ga','script');
 
           ga('create', 'UA-42485841-3', 'gulpjs.com');
           ga('send', 'pageview');


### PR DESCRIPTION
`i` `s` `o` `g` `r` `a` `m` -> `g` `u` `l` `p` `j` `s` (Re-commit of #7)

If you prefer other variables, I'll update this PR :)
For example, `g` `u` `l` `p` `I` `t`:

```js
!function(g,u,l,p,I,t){g.GoogleAnalyticsObject=l;g[l]||(g[l]=function(){
(g[l].q=g[l].q||[]).push(arguments)});g[l].l=+new Date;I=u.createElement(p);
t=u.getElementsByTagName(p)[0];I.src='//www.google-analytics.com/analytics.js';
t.parentNode.insertBefore(I,t)}(window,document,'ga','script');
```