### PR TITLE
Contribute section with backers and sponsors

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -511,3 +511,22 @@ p.paragraph {
         margin-top: 30px;
     }
 }
+
+.supporters {
+  padding: 10px 0;
+}
+.supporter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  margin: 10px;
+  float: left;
+  width: 112px;
+  height: 112px;
+  box-sizing: content-box;
+  background: #fff;
+}
+.supporter img {
+  border-radius: 3px;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -512,21 +512,85 @@ p.paragraph {
     }
 }
 
+
+@media (max-width: 750px) {
+    .footer .col-6:nth-of-type(1) {
+        margin-bottom: 0;
+    }
+    .footer .col-6 {
+        width: 100%;
+        margin-top: 30px;
+    }
+}
+
+@media (max-width: 750px) {
+    .footer .flex {
+        flex-wrap: wrap;
+    }
+}
+
 .supporters {
   padding: 10px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 .supporter {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
   border-radius: 3px;
   margin: 10px;
   float: left;
-  width: 112px;
-  height: 112px;
+  width: 80px;
+  height: 80px;
   box-sizing: content-box;
   background: #fff;
 }
+.supporter--skeleton{
+  position: relative;
+}
+.supporter--skeleton:after{
+  content:'';
+  box-sizing: border-box;
+  /* centre everything */
+  position: absolute;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+  background: #e2e2e2;
+	width: 10px;
+	height: 10px;
+  border-radius: 50%;
+  -webkit-animation: loading 1000ms ease-in-out infinite alternate;
+  -moz-animation: loading 1000ms ease-in-out infinite alternate;
+  animation: loading 1000ms ease-in-out infinite ;
+}
+
 .supporter img {
-  border-radius: 3px;
+  opacity: 1;
+  transition: opacity 400ms;
+}
+.supporter--skeleton img {
+  opacity: 0;
+}
+@-webkit-keyframes loading {
+  0% {transform: translate(-40px, -50%); opacity: 0;}
+  60% {opacity: 1;}
+  90% {opacity: 0;}
+  100% {transform: translate(27px, -50%); opacity: 0;}
+}
+@-moz-keyframes loading {
+  0% {transform: translate(-40px, -50%); opacity: 0;}
+  60% {opacity: 1;}
+  90% {opacity: 0;}
+  100% {transform: translate(27px, -50%); opacity: 0;}
+}
+@keyframes loading {
+  0% {transform: translate(-40px, -50%); opacity: 0;}
+  60% {opacity: 1;}
+  90% {opacity: 0;}
+  100% {transform: translate(27px, -50%); opacity: 0;}
 }

--- a/index.html
+++ b/index.html
@@ -136,22 +136,9 @@ gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show">
   </div>
 
   <div class="footer">
-    <div class="container-sml">
-      <div class="col-12 text-center">
+    <div class="container-lrg flex">
+      <div class="col-6 text-center">
         <div class="contribute-copy center vertical text-center">
-          <h3 class="subheading">Backers &amp; Sponsors</h3>
-          <div class="supporters" id="supporters">
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-            <div class="supporter supporter--skeleton"></div>
-          </div>
           <h3 class="subheading">Become a backer</h3>
           <p class="paragraph">
             Support the community and keep development going strong.
@@ -159,9 +146,26 @@ gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show">
           <a class="ctas-button" href="https://opencollective.com/gulpjs">Donate</a>
         </div>
       </div>
+      <div class="col-6 text-center">
+        <h3 class="subheading">Backers &amp; Sponsors</h3>
+        <div class="supporters" id="supporters">
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+          <div class="supporter supporter--skeleton"></div>
+        </div>
+      </div>
     </div>
   </div>
 
+  <script src="//unpkg.com/promise-polyfill@6.0.2/promise.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
   <script async src="/js/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -139,7 +139,20 @@ gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show">
     <div class="container-sml">
       <div class="col-12 text-center">
         <div class="contribute-copy center vertical text-center">
-          <h3 class="subheading">Become a backer</h1>
+          <h3 class="subheading">Backers &amp; Sponsors</h3>
+          <div class="supporters" id="supporters">
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+            <div class="supporter supporter--skeleton"></div>
+          </div>
+          <h3 class="subheading">Become a backer</h3>
           <p class="paragraph">
             Support the community and keep development going strong.
           </p>
@@ -148,5 +161,7 @@ gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show">
       </div>
     </div>
   </div>
+
+  <script async src="/js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,15 +1,45 @@
-Promise.all(['https://opencollective.com/gulpjs/sponsor.json','https://opencollective.com/gulpjs/backer.json'].map(url =>
-  fetch(url).then(resp => resp.json())
-)).then(entries => {
-  let html = '';
-	const supporters = [].concat.apply([], entries);
-	const supportersToDisplay = supporters
-    .sort( (first, second) => {return (second.totalDonations - first.totalDonations)} )
-    .slice(0, 10);
+(function(){
+  var services = [
+    'https://opencollective.com/gulpjs/sponsor.json',
+    'https://opencollective.com/gulpjs/backer.json'
+  ].map(function (url) {
+    return fetch(url)
+      .then(function(resp) {
+        return resp.json();
+      });
+  })
 
-	supportersToDisplay.forEach((supporter) => {
-    html += `<a class="supporter" href="${supporter.website}"><img alt="${supporter.name}" src="${supporter.avatar}" width="112"></a>`
-	});
+  Promise.all(services).then(function (entries) {
+    var fragment = document.createDocumentFragment();
+    var nodes = [];
+  	var supporters = [].concat.apply([], entries);
+  	var supportersToDisplay = supporters
+      .sort(function(first, second) {
+        return (second.totalDonations - first.totalDonations)
+      })
+      .slice(0, 10);
 
-  document.getElementById('supporters').innerHTML = html;
-});
+  	supportersToDisplay.forEach(function(supporter) {
+      var img = new Image();
+      img.src = 'https://opencollective.com/proxy/images/?src=' + supporter.avatar ;
+      img.width = 80;
+      img.onload = function(e) {
+        e.currentTarget.parentNode.classList.remove('supporter--skeleton');
+      }
+
+      var link = document.createElement('a');
+      link.className = 'supporter supporter--skeleton';
+      link.href = supporter.website;
+
+      link.appendChild(img);
+      nodes.push(link);
+  	});
+
+    nodes.forEach(function(node) {
+      fragment.appendChild(node);
+    });
+
+    document.getElementById('supporters').innerHTML = ''; // Clear prerendered items
+    document.getElementById('supporters').appendChild( fragment );
+  });
+})();

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,15 @@
+Promise.all(['https://opencollective.com/gulpjs/sponsor.json','https://opencollective.com/gulpjs/backer.json'].map(url =>
+  fetch(url).then(resp => resp.json())
+)).then(entries => {
+  let html = '';
+	const supporters = [].concat.apply([], entries);
+	const supportersToDisplay = supporters
+    .sort( (first, second) => {return (second.totalDonations - first.totalDonations)} )
+    .slice(0, 10);
+
+	supportersToDisplay.forEach((supporter) => {
+    html += `<a class="supporter" href="${supporter.website}"><img alt="${supporter.name}" src="${supporter.avatar}" width="112"></a>`
+	});
+
+  document.getElementById('supporters').innerHTML = html;
+});


### PR DESCRIPTION
This adds a section with backers and sponsors joined together.

- It shows the 10 supporters with the highest amount donated.
- Images are loaded with the OpenCollective proxy `https://opencollective.com/proxy/images/?src=`, this is a bit hacky, and maybe we should request a official endpoint, that also allows us to define size. If we do not load it with this, the images can be very very large.
- Before the data is loaded we display 10 "skeleton" frames, with a loading animation.
- When the images are loaded they will fade in.
- Code is ES5 with polyfills.
- Works with mobile, as it's responsive using the already defined classes can grid for this.

I think this is it, let me know what you think.

Animation example on a very slow connection:
![lazyloading](https://cloud.githubusercontent.com/assets/453018/25246026/a8ddf88e-2606-11e7-8c67-c9657808ac47.gif)

This will fix #51
