### PR TITLE
Round corners on the editor window

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -341,6 +341,7 @@ p.paragraph {
 }
 .editor-window {
   background-color: #141414;
+  border-radius: 5px 5px 0 0;
 }
 .editor-window .editor-menubar {
   background-color: #E5E4E4;


### PR DESCRIPTION
The menubar had border-radius: 5px, but the parent element didn't, so the black background sticks out and looks dirty. One line fix.

**Before**
![before](https://cloud.githubusercontent.com/assets/3535127/26810193/bfd879b8-4a2f-11e7-8126-bca96a108e65.png)

**Fixed**
![fixed](https://cloud.githubusercontent.com/assets/3535127/26810194/bfda6f7a-4a2f-11e7-954f-c8e8aac97e4b.png)

