### PR TITLE
link to the site in the readme was https, so I changed it to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gulpjs.com
 
-This is the repository containing the code for the official gulp website [gulpjs.com](https://gulpjs.com).
+This is the repository containing the code for the official gulp website [gulpjs.com](http://gulpjs.com).
 
 ![A screenshot of gulpjs.com](screenshot.png)
 


### PR DESCRIPTION
I know you all are keeping the site barebones, but if you are interested in hosting the site with a custom domain and ssl, I know the free tier of firebase hosting supports it. Only mention it because it was the only mainstream service I could find that supports it for free after a _lot_ of searching.

Issue: https://github.com/gulpjs/gulpjs.github.io/issues/64