### PR TITLE
Explicitly always load third-party scripts via HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,8 +164,8 @@ gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show">
     </div>
   </div>
 
-  <script src="//unpkg.com/promise-polyfill@6.0.2/promise.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+  <script src="https://unpkg.com/promise-polyfill@6.0.2/promise.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
   <script async src="/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Its safer.