### PR TITLE
Changed "Docs" link to point to 3.9.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           <img class="logo-img" src="img/gulp-white-text.svg" alt="Gulp">
         </a>
         <nav class="nav mobile-col-12 spread" role="navigation">
-          <a class="nav-link" href="https://github.com/gulpjs/gulp/blob/master/docs/API.md">Docs</a>
+          <a class="nav-link" href="https://github.com/gulpjs/gulp/blob/v3.9.1/docs/API.md">Docs</a>
           <a class="nav-link" href="https://gulpjs.com/plugins">Plugins</a>
           <a class="nav-link" href="https://twitter.com/gulpjs">Twitter</a>
           <a class="nav-link" href="https://github.com/gulpjs/gulp/blob/master/CONTRIBUTING.md">Contribute</a>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
           gulp is a toolkit for automating painful or time-consuming tasks in your development workflow, so you can stop messing around and build something.
         </h2>
         <div class="ctas">
-          <a class="ctas-button" href="https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md">Get Started</a>
+          <a class="ctas-button" href="https://github.com/gulpjs/gulp/blob/v3.9.1/docs/getting-started.md">Get Started</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The current version you get when you run `npm install gulp`– as prompted by this site– is 3.9.1. The docs should link to that version.