### PR TITLE
Leave more space between stats items on small-size devices

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -98,25 +98,25 @@
       <div class="col-3 border"></div>
     </div>
     <div class="container-lrg flex baseline">
-      <div class="col-3 text-center">
+      <div class="col-3 mobile-col-6 text-center">
         <h3 id="installs" class="subheading">100,000</h3>
         <p class="paragraph">
           Installs This Week
         </p>
       </div>
-      <div class="col-3 text-center">
+      <div class="col-3 mobile-col-6 text-center">
         <h3 id="gulp-plugins" class="subheading">1,000</h3>
         <p class="paragraph">
           Gulp Plugins
         </p>
       </div>
-      <div class="col-3 text-center">
+      <div class="col-3 mobile-col-6 text-center">
         <h3 class="subheading">1,000+</h3>
         <p class="paragraph">
           Companies
         </p>
       </div>
-      <div class="col-3 text-center">
+      <div class="col-3 mobile-col-6 text-center">
         <h3 class="subheading">
           ∞
         </h3>


### PR DESCRIPTION
On small-size devices (tried on a 6" Xiaomi Redmi Note 4) the stats items have not enough space to expand and they overlap with each other.

I add `mobile-col-6` to the items so they can take double the space on small-size devices while retaining their current layout on larger screens.

