### PR TITLE
Convert demo to Gulp 4.0.0+

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -158,35 +158,40 @@
             <span class="editor-filename">gulpfile.js</span>
           </div>
           <pre><code class="javascript hljs">
-<span class="hljs-keyword">var</span> gulp = <span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp'</span>);
-<span class="hljs-keyword">var</span> pug = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-pug'</span>);
-<span class="hljs-keyword">var</span> less = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-less'</span>);
-<span class="hljs-keyword">var</span> minifyCSS = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-csso'</span>);
-<span class="hljs-keyword">var</span> concat = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-concat'</span>);
-<span class="hljs-keyword">var</span> sourcemaps = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-sourcemaps'</span>);
+<span class="hljs-keyword">const</span> {
+  src,
+  dest,
+  parallel
+} = <span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp'</span>);
 
-gulp.task(<span class="hljs-string">'html'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{
-  <span class="hljs-keyword">return</span> gulp.src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/templates/*.pug'</span><span class="mobile-show"><br />    </span>)
+<span class="hljs-keyword">const</span> pug = <span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-pug'</span>);
+<span class="hljs-keyword">const</span> less = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-less'</span>);
+<span class="hljs-keyword">const</span> minifyCSS = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-csso'</span>);
+<span class="hljs-keyword">const</span> concat = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-concat'</span>);
+<span class="hljs-keyword">const</span> sourcemaps = <span class="mobile-show"><br />  </span><span class="hljs-built_in">require</span>(<span class="hljs-string">'gulp-sourcemaps'</span>);
+
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">html</span><span class="hljs-params">()</span> </span>{
+  <span class="hljs-keyword">return</span> src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/templates/*.pug'</span><span class="mobile-show"><br />    </span>)
     .pipe(pug())
-    .pipe(gulp.dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/html'</span><span class="mobile-show"><br />    </span>))
-});
+    .pipe(dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/html'</span><span class="mobile-show"><br />    </span>))
+}
 
-gulp.task(<span class="hljs-string">'css'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{
-  <span class="hljs-keyword">return</span> gulp.src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/templates/*.less'</span><span class="mobile-show"><br />    </span>)
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">css</span><span class="hljs-params">()</span> </span>{
+  <span class="hljs-keyword">return</span> src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/templates/*.less'</span><span class="mobile-show"><br />    </span>)
     .pipe(less())
     .pipe(minifyCSS())
-    .pipe(gulp.dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/css'</span><span class="mobile-show"><br />    </span>))
-});
+    .pipe(dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/css'</span><span class="mobile-show"><br />    </span>))
+}
 
-gulp.task(<span class="hljs-string">'js'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>)</span>{
-  <span class="hljs-keyword">return</span> gulp.src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/javascript/*.js'</span><span class="mobile-show"><br />    </span>)
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">js</span><span class="hljs-params">()</span> </span>{
+  <span class="hljs-keyword">return</span> src(<span class="mobile-show"><br />      </span><span class="hljs-string">'client/javascript/*.js'</span><span class="mobile-show"><br />    </span>)
     .pipe(sourcemaps.init())
     .pipe(concat(<span class="mobile-show"><br />      </span><span class="hljs-string">'app.min.js'</span><span class="mobile-show"><br />    </span>))
     .pipe(sourcemaps.write())
-    .pipe(gulp.dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/js'</span><span class="mobile-show"><br />    </span>))
-});
+    .pipe(dest(<span class="mobile-show"><br />      </span><span class="hljs-string">'build/js'</span><span class="mobile-show"><br />    </span>))
+}
 
-gulp.task(<span class="hljs-string">'default'</span>, <span class="mobile-show"><br />  </span>[ <span class="hljs-string">'html'</span>, <span class="hljs-string">'css'</span>, <span class="hljs-string">'js'</span> ]<span class="mobile-show"><br /></span>);
+exports.<span class="hljs-keyword">default</span> = <span class="mobile-show"><br />  </span>parallel(html, css, js);
           </code></pre>
         </div>
       </div>


### PR DESCRIPTION
Conversion of the Gulp demo/example code from API 3 to 4.

* HighlightJS automatically and manually applied.
* Switched from `var` to `const` for `require()` calls.

![demo rendered](https://user-images.githubusercontent.com/195061/50500051-593f2180-0a03-11e9-9370-6bf08c020ce9.png)
