### PR TITLE
Make window controls realistic

### DIFF
--- a/website/static/css/homepage.css
+++ b/website/static/css/homepage.css
@@ -410,14 +410,14 @@ p.paragraph {
   margin-left: 10px;
 }
 .editor-menubar .close {
-  background-color: red;
+  background-color: #fc5753;
   margin-left: 10px;
 }
 .editor-menubar .minimize {
-  background-color: yellow;
+  background-color: #fdbc40;
 }
 .editor-menubar .maximize {
-  background-color: green;
+  background-color: #33c748;
 }
 .socialproof {
   padding: 90px 0;


### PR DESCRIPTION
The terminal window close controls looked nothing like actual macOS, so I changed the colors 😄. Sure, it's trivial, but I felt like it.