### PR TITLE
fetch from Open Collective using the latest API

### DIFF
--- a/website/static/js/script.js
+++ b/website/static/js/script.js
@@ -23,7 +23,7 @@
   }
 
   function sortByTotalDonations(a, b) {
-    return a.totalDonations.value < b.totalDonations.value;
+    return b.totalDonations.value - a.totalDonations.value;
   }
 
   var supporters = services[0];

--- a/website/static/js/script.js
+++ b/website/static/js/script.js
@@ -1,6 +1,6 @@
 (function(){
   var services = [
-    'https://rest.opencollective.com/v2/gulpjs/orders/incoming/active',
+    'https://rest.opencollective.com/v2/gulpjs/orders/incoming?status=active,cancelled,paid&limit=1000',
     'https://api.npmjs.org/downloads/point/last-week/gulp',
     'https://api.npms.io/v2/search?q=keywords%3Agulpplugin',
   ].map(function (url) {

--- a/website/static/js/script.js
+++ b/website/static/js/script.js
@@ -16,9 +16,9 @@
       return o.fromAccount.slug;
     }
     return array.reduce(function(acc, curr) {
-      return acc.find(function (a) {
+      return acc.filter(function (a) {
         return predicate(a) === predicate(curr);
-      }) ? acc : acc.push(curr) && acc
+      }).length ? acc : acc.push(curr) && acc
     }, []);
   }
 

--- a/website/static/js/script.js
+++ b/website/static/js/script.js
@@ -11,8 +11,19 @@
     return resp.json();
   }
 
-  function uniqify(array, predicate) {
-    return array.reduce((acc, curr) => acc.find(a => predicate(a) === predicate(curr)) ? acc : acc.push(curr) && acc, []);
+  function uniqueBySlug(array) {
+    var predicate = function (o) {
+      return o.fromAccount.slug;
+    }
+    return array.reduce(function(acc, curr) {
+      return acc.find(function (a) {
+        return predicate(a) === predicate(curr);
+      }) ? acc : acc.push(curr) && acc
+    }, []);
+  }
+
+  function sortByTotalDonations(a, b) {
+    return a.totalDonations.value < b.totalDonations.value;
   }
 
   var supporters = services[0];
@@ -49,11 +60,18 @@
   supporters.then(function (orders) {
     var fragment = document.createDocumentFragment();
     var nodes = [];
-    var uniqueSupporters = uniqify(orders.nodes.sort((a, b) => a.totalDonations.value < b.totalDonations.value), o => o.fromAccount.slug);
+    var uniqueSupporters = uniqueBySlug(orders.nodes.sort(sortByTotalDonations));
     var supportersToDisplay = uniqueSupporters.slice(0, 10);
 
     supportersToDisplay.forEach(function(supporter) {
-      var { fromAccount: { name, slug, website, twitterHandle, imageUrl }, totalDonations } = supporter;
+      var fromAccount = supporter.fromAccount;
+      var totalDonations = supporter.totalDonations;
+
+      var name = fromAccount.name;
+      var slug = fromAccount.slug;
+      var website = fromAccount.website;
+      var twitterHandle = fromAccount.twitterHandle;
+      var imageUrl = fromAccount.imageUrl;
 
       var img = new Image();
       img.src = imageUrl;
@@ -66,7 +84,7 @@
       var link = document.createElement('a');
       link.className = 'supporter supporter--skeleton';
       link.rel = 'nofollow';
-      link.title = `${name} with $${totalDonations.value} total`;
+      link.title = name + ' with $' + totalDonations.value + ' total';
 
       if (website) {
         link.href = website;


### PR DESCRIPTION
The current endpoint used is old and deprecated. See: opencollective/opencollective#2037

This PR update to a new REST endpoint that is linked to the Open Collective GraphQL API v2.

This is supported by the Open Collective Engineering team, so happy to help if there is any problem with the endpoint or the data returned.

#### Changes

- only display sponsors with active subscriptions
- order by totalDonations client side
- remove duplicates client side
- update img.alt and a.title