### PR TITLE
Set search input size to 16px #119

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -169,6 +169,8 @@ table tr td + td + td:last-child {
 /* Search */
 .navbar .navbar__search .navbar__search-input {
   width: 15.5rem;
+  font-size: 1rem;
+  font-family: var(--ifm-font-family-base);
   border-radius: var(--ifm-global-radius);
 }
 


### PR DESCRIPTION
Fixes #119 . 

Btw, the docs.css file looks like it could use some refactoring. 
Here's some stuff I was thinking of doing: 
 - Change the file to be a SCSS file
 - Nest media queries inside CSS selectors (e.g. the way it's done in [src/theme/BackerSection/backers.module.scss](src/theme/BackerSection/backers.module.scss))
 - Group together the selectors - e.g. we are referencing `.navbar__search-input` in three different places. It will be easier to maintain if the CSS for the selector is in one place. 
 - Lower the specificity of some selectors - this could be tricky, because 1. Infima has some unnecessary heavy selectors and 2. the CSS bundling is weird and puts the custom CSS (docs.css) somewhere in the middle of the output file and its selectors are being overwritten by other CSS.

If it's OK I can open a separate PR for these?